### PR TITLE
Add prettier support with eslint config

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -4,7 +4,18 @@ The eslint configuration used for Colony OSS projects. Instrutions copied from [
 
 ## Usage
 
-Our default export contains all of our ESLint rules. It requires `eslint`, `babel-eslint`, `eslint-plugin-import`, `eslint-plugin-flowtype`, and `eslint-import-resolver-jest`.
+Our default export contains all of our ESLint rules.
+
+**Requirements**
+
+* `babel-eslint`
+* `eslint-config-prettier`
+* `eslint-import-resolver-jest`
+* `eslint-plugin-flowtype`
+* `eslint-plugin-import`
+* `eslint-plugin-prettier`
+* `eslint`
+* `prettier`
 
 If you use yarn, run `npm info "@colony/eslint-config-colony@latest" peerDependencies` to list the peer dependencies and versions, then run `yarn add --dev <dependency>@<version>` for each listed peer dependency. See below for npm instructions.
 

--- a/index.js
+++ b/index.js
@@ -3,8 +3,8 @@ module.exports = {
     'eslint-config-airbnb-base',
     'eslint-config-airbnb-base/rules/strict',
     'prettier',
-    'prettier/flowtype',
-  ].map(require.resolve),
+    'prettier/flowtype'
+  ],
   parser: 'babel-eslint',
   env: {
     es6: true,

--- a/index.js
+++ b/index.js
@@ -2,21 +2,32 @@ module.exports = {
   extends: [
     'eslint-config-airbnb-base',
     'eslint-config-airbnb-base/rules/strict',
+    'prettier',
+    'prettier/flowtype',
   ].map(require.resolve),
   parser: 'babel-eslint',
-  env:{
-      es6: true,
-      commonjs: true,
+  env: {
+    es6: true,
+    commonjs: true,
   },
   parserOptions: {
-      ecmaVersion: 6,
-      sourceType: 'module'
+    ecmaVersion: 6,
+    sourceType: 'module'
   },
-  plugins: ['flowtype'],
+  plugins: ['flowtype', 'prettier'],
   rules: {
     'eqeqeq': [2, 'smart'],
     'max-len': [2, 150],
     'no-underscore-dangle': [2, { allowAfterThis: true }],
-    'import/no-anonymous-default-export': [2]
+    'import/no-anonymous-default-export': [2],
+    'prettier/prettier': [
+      'error',
+      {
+        'parser': 'flow',
+        'printWidth': 150,
+        'singleQuote': true,
+        'trailingComma': 'es5',
+      },
+    ],
   },
 };

--- a/package.json
+++ b/package.json
@@ -11,7 +11,10 @@
   "peerDependencies": {
     "babel-eslint": "^8.0.2",
     "eslint-config-airbnb-base": "^12.1.0",
-    "eslint-plugin-flowtype": "^2.39.1"
+    "eslint-config-prettier": "^2.9.0",
+    "eslint-plugin-flowtype": "^2.39.1",
+    "eslint-plugin-prettier": "^2.5.0",
+    "prettier": "^1.10.2"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
* Adds configuration for prettier and integrates it so that it is run in tandem with eslint
* Adds more peerDependencies:
  - `eslint-config-prettier`
  - `eslint-plugin-prettier`
  - `prettier`
